### PR TITLE
Moved to newer FastMCP packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ENV OPENHAB_URL=http://openhab:8080
 ENV OPENHAB_API_TOKEN=""
 ENV OPENHAB_USERNAME=""
 ENV OPENHAB_PASSWORD=""
-
+ENV TRANSPORT_TYPE="stdio"
+ENV MCP_PORT="8000"
 # Run the MCP server when the container launches
 CMD ["python", "openhab_mcp_server.py"]

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ docker-run:
 		-e OPENHAB_API_TOKEN=${OPENHAB_API_TOKEN} \
 		-e OPENHAB_USERNAME=${OPENHAB_USERNAME} \
 		-e OPENHAB_PASSWORD=${OPENHAB_PASSWORD} \
+		-e TRANSPORT_TYPE=${TRANSPORT_TYPE} \
 		--name openhab-mcp \
 		openhab-mcp
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       - OPENHAB_API_TOKEN=${OPENHAB_API_TOKEN:-}
       - OPENHAB_USERNAME=${OPENHAB_USERNAME:-}
       - OPENHAB_PASSWORD=${OPENHAB_PASSWORD:-}
+      - TRANSPORT_TYPE=${TRANSPORT_TYPE:-}
+      - MCP_PORT=${MCP_PORT:-}
       - PORT=8081
     depends_on:
       openhab:

--- a/openhab_mcp_server.py
+++ b/openhab_mcp_server.py
@@ -4,6 +4,7 @@ OpenHAB MCP Server - An MCP server that interacts with a real openHAB instance.
 
 This server uses mcp.server for simplified MCP server implementation and
 connects to a real openHAB instance via its REST API.
+
 """
 
 import logging
@@ -18,9 +19,7 @@ from dotenv import load_dotenv
 logging.basicConfig(level=logging.WARNING)
 
 # Import the MCP server implementation
-from mcp.server import FastMCP
-from mcp.server.stdio import stdio_server
-from mcp.types import INVALID_REQUEST, JSONRPCError
+from fastmcp.server import FastMCP
 
 # Import our modules
 from models import EnrichedItemChannelLinkDTO, Item, ItemChannelLinkDTO, Rule, Thing
@@ -39,6 +38,12 @@ OPENHAB_URL = os.environ.get("OPENHAB_URL", "http://localhost:8080")
 OPENHAB_API_TOKEN = os.environ.get("OPENHAB_API_TOKEN")
 OPENHAB_USERNAME = os.environ.get("OPENHAB_USERNAME")
 OPENHAB_PASSWORD = os.environ.get("OPENHAB_PASSWORD")
+TRANSPORT_TYPE = os.environ.get("TRANSPORT_TYPE", "stdio")
+MCP_PORT = os.environ.get("MCP_PORT", "8000")
+
+# possible FastMCP connection types
+TRANSPORT_TYPES = ["stdio", "http", "sse"]
+
 
 if not OPENHAB_API_TOKEN and not (OPENHAB_USERNAME and OPENHAB_PASSWORD):
     print(
@@ -264,7 +269,15 @@ def delete_all_links_for_object(object_name: str) -> bool:
 
 def main():
     """Main entry point for the OpenHAB MCP server."""
-    mcp.run()
+    if TRANSPORT_TYPE in TRANSPORT_TYPES:
+        if TRANSPORT_TYPE == "stdio":
+            mcp.run(transport=TRANSPORT_TYPE)
+        elif TRANSPORT_TYPE == "http":
+            mcp.run(transport=TRANSPORT_TYPE, host="127.0.0.1", port=int(MCP_PORT), path="/mcp")
+        elif TRANSPORT_TYPE == "sse":
+            mcp.run(transport=TRANSPORT_TYPE, host="127.0.0.1", port=int(MCP_PORT))
+    else:
+        print("Transport-Type has to be stdio, http or sse")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp",
+    "fastmcp",
     "python-dotenv",
     "requests",
     "pydantic",


### PR DESCRIPTION
### **User description**
- Added different transport types: stdio (like before), http and sse 
- Added options for transport-type and mcp_port

SSE works e.g. with newest N8N and MCP Client node


___

### **PR Type**
Enhancement


___

### **Description**
- Upgraded from `mcp` to `fastmcp` package

- Added support for multiple transport types (stdio, http, sse)

- Added configurable MCP port option

- Updated Docker and deployment configurations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old mcp package"] --> B["FastMCP package"]
  B --> C["stdio transport"]
  B --> D["http transport"]
  B --> E["sse transport"]
  F["Environment config"] --> G["TRANSPORT_TYPE"]
  F --> H["MCP_PORT"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openhab_mcp_server.py</strong><dd><code>Core server upgrade to FastMCP with transport options</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openhab_mcp_server.py

<ul><li>Replaced <code>mcp.server</code> imports with <code>fastmcp.server</code><br> <li> Added transport type validation and configuration logic<br> <li> Added environment variables for <code>TRANSPORT_TYPE</code> and <code>MCP_PORT</code><br> <li> Updated main function to handle different transport types with <br>specific configurations</ul>


</details>


  </td>
  <td><a href="https://github.com/tdeckers/openhab-mcp/pull/1/files#diff-31bf0dec1087a1e3b1921e16c622369859319a1032c02a81d14dad8c37fa5039">+17/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Docker environment variables for transport configuration</code>&nbsp; </dd></summary>
<hr>

Dockerfile

<ul><li>Added <code>TRANSPORT_TYPE</code> environment variable with default "stdio"<br> <li> Added <code>MCP_PORT</code> environment variable with default "8000"</ul>


</details>


  </td>
  <td><a href="https://github.com/tdeckers/openhab-mcp/pull/1/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Makefile transport type environment support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

- Added `TRANSPORT_TYPE` environment variable to docker-run target


</details>


  </td>
  <td><a href="https://github.com/tdeckers/openhab-mcp/pull/1/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Docker Compose transport configuration support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<ul><li>Added <code>TRANSPORT_TYPE</code> and <code>MCP_PORT</code> environment variables<br> <li> Both variables use default fallback values</ul>


</details>


  </td>
  <td><a href="https://github.com/tdeckers/openhab-mcp/pull/1/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Package dependency upgrade to FastMCP</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

- Replaced `mcp` dependency with `fastmcp`


</details>


  </td>
  <td><a href="https://github.com/tdeckers/openhab-mcp/pull/1/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

