### PR TITLE
Add QEMU setup for Docker multi-platform support

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,6 +24,8 @@ jobs:
         
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -47,6 +50,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
### **User description**
Added QEMU setup step for multi-platform builds.


___

### **PR Type**
Enhancement


___

### **Description**
- Add QEMU setup step for multi-platform Docker builds

- Enable building Docker images for multiple architectures (amd64, arm64)

- Configure GitHub Actions workflow to support cross-platform compilation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Actions Workflow"] --> B["Set up QEMU"]
  B --> C["Set up Docker Buildx"]
  C --> D["Build and Push"]
  D --> E["Multi-platform Images<br/>amd64, arm64"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-image.yml</strong><dd><code>Enable multi-platform Docker builds with QEMU</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-image.yml

<ul><li>Added QEMU setup step using <code>docker/setup-qemu-action@v3</code> for <br>multi-platform support<br> <li> Added <code>platforms: linux/amd64,linux/arm64</code> configuration to <br>build-push-action step<br> <li> Enables building Docker images for both AMD64 and ARM64 architectures</ul>


</details>


  </td>
  <td><a href="https://github.com/tdeckers/openhab-mcp/pull/6/files#diff-dbade1e5797a7633e024a7685a43a7cbd96ae6fefc6314294807ae34cd83712c">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

