### PR TITLE
Add remote MCP mode with both HTTP transports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,11 @@
 # AGENTS.md
 
 ## Purpose
+
 This repo is an MCP server that talks to a real openHAB instance over its REST API. It can run as a local Python app or in a Podman/Docker container. There are smoke tests under `tests/`.
 
 ## Key files
+
 - `openhab_mcp_server.py`: MCP server entrypoint (`openhab-mcp` console script).
 - `openhab_client.py`: REST client for openHAB.
 - `models.py`: Pydantic models.
@@ -11,6 +13,7 @@ This repo is an MCP server that talks to a real openHAB instance over its REST A
 - `Makefile`: Container build/run/dev commands.
 
 ## Common commands
+
 - Install deps: `uv sync` (add `--extra dev` for dev tools)
 - Run tests: `uv run pytest`
 - Lint/format (dev extras): `uv run flake8`, `uv run isort .`, `uv run black .`
@@ -19,14 +22,16 @@ This repo is an MCP server that talks to a real openHAB instance over its REST A
 - Dev env: `make dev-env` (podman-compose)
 
 ## Runtime notes
-- Streamable HTTP transport is preferred: set `MCP_TRANSPORT=http` and use `http://HOST:PORT/mcp`.
-- SSE is still supported: set `MCP_TRANSPORT=sse` and use `http://HOST:PORT/sse`.
+
+- Remote mode exposes both transports on one port: set `MCP_MODE=remote` and use `http://HOST:PORT/mcp` (Streamable HTTP) or `http://HOST:PORT/sse` (SSE).
 - Default MCP container examples map `8000` inside to `8081` on host.
 
 ## Testing notes
+
 - Use `uv run` for local commands to ensure the locked environment is used.
 - Tests may require a reachable openHAB instance; if failing locally, verify `OPENHAB_URL` and `OPENHAB_API_TOKEN`.
 
 ## Style
+
 - Python formatting: Black (88 columns) and isort.
 - Lint rules: flake8 with `E203,W503` ignored.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -9,7 +9,7 @@ For development, the recommended approach is to use Podman:
 A docker-compose file is provided for running both OpenHAB and the MCP server in containers using podman-compose.
 Run the following command to start the containers:
 
-Streamable HTTP is the preferred transport for HTTP clients. Use `MCP_TRANSPORT=http` and connect to `http://HOST:PORT/mcp`. SSE remains available for backwards compatibility at `http://HOST:PORT/sse` with `MCP_TRANSPORT=sse`.
+Remote mode exposes both transports on one port. Use `MCP_MODE=remote` and connect to `http://HOST:PORT/mcp` (Streamable HTTP) or `http://HOST:PORT/sse` (SSE).
 
 ```bash
 # Using podman-compose directly

--- a/README.md
+++ b/README.md
@@ -56,27 +56,25 @@ By default the server uses stdio for MCP. For remote HTTP clients, set `MCP_MODE
 
    ```bash
    podman run -d --rm -p 8081:8000 \
-
-  -e MCP_MODE=remote \
-     -e OPENHAB_URL=<http://your-openhab-host:8080> \
-     -e OPENHAB_API_TOKEN=your-api-token \
-     --name openhab-mcp \
-     ghcr.io/tdeckers/openhab-mcp:latest
-
-   ```
-
-   Using Docker instead?
-
-   ```bash
-   docker run -d --rm -p 8081:8000 \
-  -e MCP_MODE=remote \
+     -e MCP_MODE=remote \
      -e OPENHAB_URL=http://your-openhab-host:8080 \
      -e OPENHAB_API_TOKEN=your-api-token \
      --name openhab-mcp \
      ghcr.io/tdeckers/openhab-mcp:latest
    ```
 
-1. Stop the container when you are done:
+   Using Docker instead?
+
+   ```bash
+   docker run -d --rm -p 8081:8000 \
+     -e MCP_MODE=remote \
+     -e OPENHAB_URL=http://your-openhab-host:8080 \
+     -e OPENHAB_API_TOKEN=your-api-token \
+     --name openhab-mcp \
+     ghcr.io/tdeckers/openhab-mcp:latest
+   ```
+
+3. Stop the container when you are done:
 
    ```bash
    podman stop openhab-mcp
@@ -102,13 +100,11 @@ If you need to modify the code, build and tag the image locally instead:
    make docker-run
    # or directly:
    podman run -d --rm -p 8081:8000 \
-
-  -e MCP_MODE=remote \
-     -e OPENHAB_URL=<http://your-openhab-host:8080> \
+     -e MCP_MODE=remote \
+     -e OPENHAB_URL=http://your-openhab-host:8080 \
      -e OPENHAB_API_TOKEN=your-api-token \
      --name openhab-mcp \
      openhab-mcp
-
    ```
 
    Ensure the `OPENHAB_URL`, `OPENHAB_API_TOKEN`, and optional `OPENHAB_USERNAME`/`OPENHAB_PASSWORD` variables are set in your shell before invoking `make docker-run`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - OPENHAB_API_TOKEN=${OPENHAB_API_TOKEN:-}
       - OPENHAB_USERNAME=${OPENHAB_USERNAME:-}
       - OPENHAB_PASSWORD=${OPENHAB_PASSWORD:-}
-      - MCP_TRANSPORT=http
+      - MCP_MODE=remote
     depends_on:
       openhab:
         condition: service_healthy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "python-dotenv",
     "requests",
     "pydantic",
+    "starlette",
+    "uvicorn",
 ]
 
 [project.optional-dependencies]

--- a/scripts/mcp_client_sse_list_items.py
+++ b/scripts/mcp_client_sse_list_items.py
@@ -1,0 +1,18 @@
+import asyncio
+import os
+
+from mcp.client.session import ClientSession
+from mcp.client.sse import sse_client
+
+
+async def main() -> None:
+    base_url = os.environ.get("MCP_HTTP_BASE", "http://localhost:8081")
+    async with sse_client(f"{base_url}/sse") as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool("list_items", arguments={"page": 1})
+            print(result.structuredContent or result.content)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/mcp_client_stdio_list_items.py
+++ b/scripts/mcp_client_stdio_list_items.py
@@ -1,0 +1,21 @@
+import asyncio
+
+from mcp.client.session import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+
+async def main() -> None:
+    server_params = StdioServerParameters(
+        command="uv",
+        args=["run", "openhab_mcp_server.py"],
+    )
+
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool("list_items", arguments={"page": 1})
+            print(result.structuredContent or result.content)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/mcp_client_streamable_list_items.py
+++ b/scripts/mcp_client_streamable_list_items.py
@@ -1,0 +1,22 @@
+import asyncio
+import os
+
+from mcp.client.session import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+
+async def main() -> None:
+    base_url = os.environ.get("MCP_HTTP_BASE", "http://localhost:8081")
+    async with streamablehttp_client(f"{base_url}/mcp") as (
+        read,
+        write,
+        _,
+    ):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool("list_items", arguments={"page": 1})
+            print(result.structuredContent or result.content)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_transport_smoke.py
+++ b/tests/test_transport_smoke.py
@@ -15,37 +15,58 @@ def _set_base_env(monkeypatch):
     monkeypatch.delenv("OPENHAB_PASSWORD", raising=False)
 
 
-def test_transport_defaults_to_stdio(monkeypatch):
+def test_mode_defaults_to_stdio(monkeypatch):
     _set_base_env(monkeypatch)
+    monkeypatch.delenv("MCP_MODE", raising=False)
     monkeypatch.delenv("MCP_TRANSPORT", raising=False)
 
     module = _load_module()
 
-    assert module.MCP_TRANSPORT == "stdio"
+    assert module.MCP_MODE == "stdio"
 
 
-def test_transport_http_aliases_to_streamable_http(monkeypatch):
+def test_mode_remote_explicit(monkeypatch):
     _set_base_env(monkeypatch)
-
-    for value in ("http", "streamable-http", "streamable_http"):
-        monkeypatch.setenv("MCP_TRANSPORT", value)
-        module = _load_module()
-        assert module.MCP_TRANSPORT == "streamable-http"
-
-
-def test_transport_sse_kept(monkeypatch):
-    _set_base_env(monkeypatch)
-    monkeypatch.setenv("MCP_TRANSPORT", "sse")
+    monkeypatch.setenv("MCP_MODE", "remote")
 
     module = _load_module()
 
-    assert module.MCP_TRANSPORT == "sse"
+    assert module.MCP_MODE == "remote"
 
 
-def test_transport_invalid_falls_back_to_stdio(monkeypatch):
+def test_mode_invalid_falls_back_to_stdio(monkeypatch):
+    _set_base_env(monkeypatch)
+    monkeypatch.setenv("MCP_MODE", "nope")
+
+    module = _load_module()
+
+    assert module.MCP_MODE == "stdio"
+
+
+def test_transport_aliases_to_remote(monkeypatch):
+    _set_base_env(monkeypatch)
+
+    for value in ("http", "streamable-http", "streamable_http", "sse"):
+        monkeypatch.delenv("MCP_MODE", raising=False)
+        monkeypatch.setenv("MCP_TRANSPORT", value)
+        module = _load_module()
+        assert module.MCP_MODE == "remote"
+
+
+def test_transport_invalid_does_not_change_default(monkeypatch):
     _set_base_env(monkeypatch)
     monkeypatch.setenv("MCP_TRANSPORT", "nope")
 
     module = _load_module()
 
-    assert module.MCP_TRANSPORT == "stdio"
+    assert module.MCP_MODE == "stdio"
+
+
+def test_mode_overrides_transport(monkeypatch):
+    _set_base_env(monkeypatch)
+    monkeypatch.setenv("MCP_MODE", "remote")
+    monkeypatch.setenv("MCP_TRANSPORT", "nope")
+
+    module = _load_module()
+
+    assert module.MCP_MODE == "remote"

--- a/uv.lock
+++ b/uv.lock
@@ -360,6 +360,8 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "requests" },
+    { name = "starlette" },
+    { name = "uvicorn" },
 ]
 
 [package.optional-dependencies]
@@ -384,6 +386,8 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "python-dotenv" },
     { name = "requests" },
+    { name = "starlette" },
+    { name = "uvicorn" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
## Summary
- Add `MCP_MODE=remote` to serve Streamable HTTP (`/mcp`) and SSE (`/sse`) at the same time
- Mount both transports via Starlette + Uvicorn when in remote mode
- Update docs, `docker-compose.yml`, and transport tests
- Add local client scripts plus a test plan

## Testing
- `uv run pytest`
- `make docker-build`
- `make dev-env`
- `uv run python scripts/mcp_client_stdio_list_items.py`
- `MCP_HTTP_BASE=http://localhost:8000 uv run python scripts/mcp_client_streamable_list_items.py`
- `MCP_HTTP_BASE=http://localhost:8000 uv run python scripts/mcp_client_sse_list_items.py`
