### PR TITLE
Add item metadata support to the openHAB MCP

### DIFF
--- a/models.py
+++ b/models.py
@@ -3,6 +3,13 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 
 
+class ItemMetadata(BaseModel):
+    """Metadata entry attached to an item under a namespace."""
+
+    value: str = ""
+    config: Dict[str, Any] = Field(default_factory=dict)
+
+
 class Item(BaseModel):
     type: str = "String"
     name: str
@@ -10,6 +17,7 @@ class Item(BaseModel):
     label: Optional[str] = None
     tags: List[str] = []
     groupNames: List[str] = []
+    metadata: Dict[str, ItemMetadata] = Field(default_factory=dict)
 
 
 class ThingStatusInfo(BaseModel):

--- a/openhab_client.py
+++ b/openhab_client.py
@@ -310,31 +310,28 @@ class OpenHABClient:
         if not item_name:
             raise ValueError("Item name is required")
 
-        if namespace is None:
-            response = self.session.get(
-                f"{self.base_url}/rest/items/{item_name}/metadata"
-            )
-            if response.status_code == 404:
-                raise ValueError(f"Item with name '{item_name}' not found")
-
-            response.raise_for_status()
-            return {
-                namespace: ItemMetadata(**metadata)
-                for namespace, metadata in response.json().items()
-            }
-
-        metadata_url = (
-            f"{self.base_url}/rest/items/{item_name}/metadata/"
-            f"{quote(namespace, safe='')}"
+        metadata_selector = namespace if namespace is not None else ".*"
+        response = self.session.get(
+            f"{self.base_url}/rest/items/{item_name}",
+            params={"metadata": metadata_selector},
         )
-        response = self.session.get(metadata_url)
         if response.status_code == 404:
+            raise ValueError(f"Item with name '{item_name}' not found")
+
+        response.raise_for_status()
+        metadata = {
+            metadata_namespace: ItemMetadata(**metadata_entry)
+            for metadata_namespace, metadata_entry in response.json()
+            .get("metadata", {})
+            .items()
+        }
+
+        if namespace is not None and namespace not in metadata:
             raise ValueError(
                 f"Metadata namespace '{namespace}' for item '{item_name}' not found"
             )
 
-        response.raise_for_status()
-        return {namespace: ItemMetadata(**response.json())}
+        return metadata
 
     def set_item_metadata(
         self,
@@ -395,7 +392,13 @@ class OpenHABClient:
         if not item_name:
             raise ValueError("Item name is required")
 
-        return sorted(self.get_item_metadata(item_name).keys())
+        metadata_url = f"{self.base_url}/rest/items/{item_name}/metadata/namespaces"
+        response = self.session.get(metadata_url)
+        if response.status_code == 404:
+            raise ValueError(f"Item with name '{item_name}' not found")
+
+        response.raise_for_status()
+        return sorted(response.json())
 
     def list_things(
         self,

--- a/openhab_client.py
+++ b/openhab_client.py
@@ -89,7 +89,9 @@ class OpenHABClient:
         )
 
         total_elements = len(filtered_items)
-        total_pages = (total_elements + page_size - 1) // page_size if page_size > 0 else 0
+        total_pages = (
+            (total_elements + page_size - 1) // page_size if page_size > 0 else 0
+        )
         start_idx = (page - 1) * page_size
         end_idx = start_idx + page_size
         paginated_items = filtered_items[start_idx:end_idx]
@@ -137,7 +139,10 @@ class OpenHABClient:
         if not item.name:
             raise ValueError("Item must have a name")
 
-        payload = item.dict()
+        if hasattr(item, "model_dump"):
+            payload = item.model_dump(exclude={"metadata"})
+        else:
+            payload = item.dict(exclude={"metadata"})
 
         response = self.session.put(
             f"{self.base_url}/rest/items/{item.name}", json=payload
@@ -185,7 +190,7 @@ class OpenHABClient:
     def list_links(
         self, channel_uid: Optional[str] = None, item_name: Optional[str] = None
     ) -> List[EnrichedItemChannelLinkDTO]:
-        """List all item-channel links, optionally filtered by channel UID or item name"""
+        """List item-channel links, optionally filtered by channel UID or item name."""
         params = {}
         if channel_uid:
             params["channelUID"] = channel_uid
@@ -300,18 +305,36 @@ class OpenHABClient:
     ) -> Dict[str, ItemMetadata]:
         """Get metadata for an item.
 
-        ``namespace`` is a namespace selector passed to openHAB (a regex or a
-        comma-separated list). When omitted, all namespaces are returned.
+        When ``namespace`` is omitted, all namespaces are returned.
         """
         if not item_name:
             raise ValueError("Item name is required")
 
-        selector = namespace if namespace is not None else ".*"
-        item = self.get_item(item_name, metadata=selector)
-        if item is None:
-            raise ValueError(f"Item with name '{item_name}' not found")
+        if namespace is None:
+            response = self.session.get(
+                f"{self.base_url}/rest/items/{item_name}/metadata"
+            )
+            if response.status_code == 404:
+                raise ValueError(f"Item with name '{item_name}' not found")
 
-        return item.metadata
+            response.raise_for_status()
+            return {
+                namespace: ItemMetadata(**metadata)
+                for namespace, metadata in response.json().items()
+            }
+
+        metadata_url = (
+            f"{self.base_url}/rest/items/{item_name}/metadata/"
+            f"{quote(namespace, safe='')}"
+        )
+        response = self.session.get(metadata_url)
+        if response.status_code == 404:
+            raise ValueError(
+                f"Metadata namespace '{namespace}' for item '{item_name}' not found"
+            )
+
+        response.raise_for_status()
+        return {namespace: ItemMetadata(**response.json())}
 
     def set_item_metadata(
         self,
@@ -328,10 +351,11 @@ class OpenHABClient:
 
         payload: Dict[str, Any] = {"value": value, "config": config or {}}
 
-        response = self.session.put(
-            f"{self.base_url}/rest/items/{item_name}/metadata/{quote(namespace, safe='')}",
-            json=payload,
+        metadata_url = (
+            f"{self.base_url}/rest/items/{item_name}/metadata/"
+            f"{quote(namespace, safe='')}"
         )
+        response = self.session.put(metadata_url, json=payload)
 
         if response.status_code == 404:
             raise ValueError(f"Item with name '{item_name}' not found")
@@ -352,9 +376,11 @@ class OpenHABClient:
         if not namespace:
             raise ValueError("Namespace is required")
 
-        response = self.session.delete(
-            f"{self.base_url}/rest/items/{item_name}/metadata/{quote(namespace, safe='')}"
+        metadata_url = (
+            f"{self.base_url}/rest/items/{item_name}/metadata/"
+            f"{quote(namespace, safe='')}"
         )
+        response = self.session.delete(metadata_url)
 
         if response.status_code == 404:
             raise ValueError(
@@ -369,10 +395,7 @@ class OpenHABClient:
         if not item_name:
             raise ValueError("Item name is required")
 
-        item = self.get_item(item_name, metadata=".*")
-        if item is None:
-            raise ValueError(f"Item with name '{item_name}' not found")
-        return sorted(item.metadata.keys())
+        return sorted(self.get_item_metadata(item_name).keys())
 
     def list_things(
         self,
@@ -419,7 +442,9 @@ class OpenHABClient:
         )
 
         total_elements = len(filtered_things)
-        total_pages = (total_elements + page_size - 1) // page_size if page_size > 0 else 0
+        total_pages = (
+            (total_elements + page_size - 1) // page_size if page_size > 0 else 0
+        )
         start_idx = (page - 1) * page_size
         end_idx = start_idx + page_size
         paginated_things = filtered_things[start_idx:end_idx]
@@ -573,9 +598,11 @@ class OpenHABClient:
             raise ValueError("Thing UID is required")
 
         try:
-            response = self.session.get(
-                f"{self.base_url}/rest/things/{quote(thing_uid, safe='')}/firmware/status"
+            firmware_status_url = (
+                f"{self.base_url}/rest/things/{quote(thing_uid, safe='')}"
+                "/firmware/status"
             )
+            response = self.session.get(firmware_status_url)
             if response.status_code == 204:
                 return None  # No firmware status provided
             response.raise_for_status()
@@ -710,18 +737,18 @@ class OpenHABClient:
         return True
 
     def list_scripts(self) -> List[Rule]:
-        """List all scripts. A script is a rule without a trigger and tag of 'Script'"""
+        """List scripts, which are rules without triggers and tagged 'Script'."""
         return self.list_rules(filter_tag="Script")
 
     def get_script(self, script_id: str) -> Optional[Rule]:
-        """Get a specific script by ID. A script is a rule without a trigger and tag of 'Script'"""
+        """Get a script by ID."""
         if script_id is None:
             return None
 
         return self.get_rule(script_id)
 
     def create_script(self, script_id: str, script_type: str, content: str) -> Rule:
-        """Create a new script.  A script is a rule without a trigger and tag of 'Script'"""
+        """Create a script rule."""
         if not script_id:
             raise ValueError("Script must have an ID")
         if not content:
@@ -749,7 +776,7 @@ class OpenHABClient:
         return self.create_rule(rule)
 
     def update_script(self, script_id: str, script_type: str, content: str) -> Rule:
-        """Update an existing script. A script is a rule without a trigger and tag of 'Script'"""
+        """Update a script rule."""
         rule = self.get_rule(script_id)
         # Check if script exists
         if not rule:

--- a/openhab_client.py
+++ b/openhab_client.py
@@ -10,6 +10,7 @@ from models import (
     FirmwareStatusDTO,
     Item,
     ItemChannelLinkDTO,
+    ItemMetadata,
     PaginatedItems,
     PaginatedThings,
     PaginationInfo,
@@ -104,13 +105,26 @@ class OpenHABClient:
 
         return PaginatedItems(items=paginated_items, pagination=pagination)
 
-    def get_item(self, item_name: str) -> Optional[Item]:
-        """Get a specific item by name"""
+    def get_item(
+        self, item_name: str, metadata: Optional[str] = None
+    ) -> Optional[Item]:
+        """Get a specific item by name.
+
+        When ``metadata`` is provided it is passed to openHAB as a namespace
+        selector (regex or comma-separated list, e.g. ``"semantics,homekit"``
+        or ``".*"``) so the returned item includes metadata entries.
+        """
         if item_name is None:
             return None
 
+        params = {}
+        if metadata is not None:
+            params["metadata"] = metadata
+
         try:
-            response = self.session.get(f"{self.base_url}/rest/items/{item_name}")
+            response = self.session.get(
+                f"{self.base_url}/rest/items/{item_name}", params=params
+            )
             response.raise_for_status()
             return Item(**response.json())
         except requests.exceptions.HTTPError as e:
@@ -280,6 +294,85 @@ class OpenHABClient:
 
         # Get the updated item
         return self.get_item(item_name)
+
+    def get_item_metadata(
+        self, item_name: str, namespace: Optional[str] = None
+    ) -> Dict[str, ItemMetadata]:
+        """Get metadata for an item.
+
+        ``namespace`` is a namespace selector passed to openHAB (a regex or a
+        comma-separated list). When omitted, all namespaces are returned.
+        """
+        if not item_name:
+            raise ValueError("Item name is required")
+
+        selector = namespace if namespace is not None else ".*"
+        item = self.get_item(item_name, metadata=selector)
+        if item is None:
+            raise ValueError(f"Item with name '{item_name}' not found")
+
+        return item.metadata
+
+    def set_item_metadata(
+        self,
+        item_name: str,
+        namespace: str,
+        value: str,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> ItemMetadata:
+        """Add or update item metadata in a namespace."""
+        if not item_name:
+            raise ValueError("Item name is required")
+        if not namespace:
+            raise ValueError("Namespace is required")
+
+        payload: Dict[str, Any] = {"value": value, "config": config or {}}
+
+        response = self.session.put(
+            f"{self.base_url}/rest/items/{item_name}/metadata/{quote(namespace, safe='')}",
+            json=payload,
+        )
+
+        if response.status_code == 404:
+            raise ValueError(f"Item with name '{item_name}' not found")
+
+        response.raise_for_status()
+
+        # openHAB returns 201 Created with an empty body on new namespaces,
+        # and 200 OK with the updated entry on updates. Echo the input back
+        # when there is no body.
+        if response.status_code == 201 or not response.content:
+            return ItemMetadata(**payload)
+        return ItemMetadata(**response.json())
+
+    def delete_item_metadata(self, item_name: str, namespace: str) -> bool:
+        """Remove an item's metadata from a namespace."""
+        if not item_name:
+            raise ValueError("Item name is required")
+        if not namespace:
+            raise ValueError("Namespace is required")
+
+        response = self.session.delete(
+            f"{self.base_url}/rest/items/{item_name}/metadata/{quote(namespace, safe='')}"
+        )
+
+        if response.status_code == 404:
+            raise ValueError(
+                f"Metadata namespace '{namespace}' for item '{item_name}' not found"
+            )
+
+        response.raise_for_status()
+        return True
+
+    def list_metadata_namespaces(self, item_name: str) -> List[str]:
+        """List metadata namespaces defined on an item."""
+        if not item_name:
+            raise ValueError("Item name is required")
+
+        item = self.get_item(item_name, metadata=".*")
+        if item is None:
+            raise ValueError(f"Item with name '{item_name}' not found")
+        return sorted(item.metadata.keys())
 
     def list_things(
         self,

--- a/openhab_mcp_server.py
+++ b/openhab_mcp_server.py
@@ -29,6 +29,7 @@ from models import (
     FirmwareStatusDTO,
     Item,
     ItemChannelLinkDTO,
+    ItemMetadata,
     Rule,
     Thing,
     ThingDTO,
@@ -131,9 +132,14 @@ def list_items(
 
 
 @mcp.tool()
-def get_item(item_name: str) -> Optional[Item]:
-    """Get a specific openHAB item by name"""
-    item = openhab_client.get_item(item_name)
+def get_item(item_name: str, metadata: Optional[str] = None) -> Optional[Item]:
+    """Get a specific openHAB item by name.
+
+    When ``metadata`` is provided (a namespace selector such as ``"semantics"``,
+    a comma-separated list, or ``".*"`` for all) the returned item includes its
+    metadata entries.
+    """
+    item = openhab_client.get_item(item_name, metadata=metadata)
     return item
 
 
@@ -162,6 +168,42 @@ def update_item_state(item_name: str, state: str) -> Item:
     """Update the state of an openHAB item"""
     updated_item = openhab_client.update_item_state(item_name, state)
     return updated_item
+
+
+@mcp.tool()
+def get_item_metadata(
+    item_name: str, namespace: Optional[str] = None
+) -> Dict[str, ItemMetadata]:
+    """Get metadata for an openHAB item.
+
+    ``namespace`` is a namespace selector (e.g. ``"semantics"``, a
+    comma-separated list, or a regex). If omitted, all namespaces are
+    returned.
+    """
+    return openhab_client.get_item_metadata(item_name, namespace=namespace)
+
+
+@mcp.tool()
+def set_item_metadata(
+    item_name: str,
+    namespace: str,
+    value: str,
+    config: Optional[Dict[str, Any]] = None,
+) -> ItemMetadata:
+    """Add or update metadata for an openHAB item in a given namespace."""
+    return openhab_client.set_item_metadata(item_name, namespace, value, config)
+
+
+@mcp.tool()
+def delete_item_metadata(item_name: str, namespace: str) -> bool:
+    """Delete metadata for an openHAB item in a given namespace."""
+    return openhab_client.delete_item_metadata(item_name, namespace)
+
+
+@mcp.tool()
+def list_metadata_namespaces(item_name: str) -> List[str]:
+    """List metadata namespaces defined on an openHAB item."""
+    return openhab_client.list_metadata_namespaces(item_name)
 
 
 @mcp.tool()

--- a/tests/test_openhab_client.py
+++ b/tests/test_openhab_client.py
@@ -1,0 +1,104 @@
+from models import Item, ItemMetadata
+from openhab_client import OpenHABClient
+
+
+class FakeResponse:
+    def __init__(self, json_data=None, status_code=200, content=b"{}"):
+        self._json_data = json_data
+        self.status_code = status_code
+        self.content = content
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        return None
+
+
+class RecordingSession:
+    def __init__(self):
+        self.headers = {}
+        self.requests = []
+        self.next_get = FakeResponse(
+            {
+                "type": "String",
+                "name": "TestItem",
+            }
+        )
+        self.next_put = FakeResponse()
+
+    def get(self, url, **kwargs):
+        self.requests.append(("GET", url, kwargs))
+        return self.next_get
+
+    def put(self, url, **kwargs):
+        self.requests.append(("PUT", url, kwargs))
+        return self.next_put
+
+
+def _client_with_session(session):
+    client = OpenHABClient("http://openhab.example")
+    client.session = session
+    return client
+
+
+def test_create_item_excludes_metadata_from_payload():
+    session = RecordingSession()
+    client = _client_with_session(session)
+    item = Item(
+        name="TestItem",
+        metadata={"semantics": ItemMetadata(value="Point", config={"relatesTo": "x"})},
+    )
+
+    client.create_item(item)
+
+    put_request = session.requests[0]
+    assert put_request[0] == "PUT"
+    assert put_request[2]["json"] == {
+        "type": "String",
+        "name": "TestItem",
+        "state": None,
+        "label": None,
+        "tags": [],
+        "groupNames": [],
+    }
+
+
+def test_get_item_metadata_fetches_all_namespaces_from_metadata_endpoint():
+    session = RecordingSession()
+    session.next_get = FakeResponse(
+        {
+            "semantics": {"value": "Point", "config": {"isPointOf": "Kitchen"}},
+            "homekit": {"value": "Lighting", "config": {}},
+        }
+    )
+    client = _client_with_session(session)
+
+    metadata = client.get_item_metadata("TestItem")
+
+    assert session.requests == [
+        ("GET", "http://openhab.example/rest/items/TestItem/metadata", {})
+    ]
+    assert metadata["semantics"] == ItemMetadata(
+        value="Point", config={"isPointOf": "Kitchen"}
+    )
+    assert metadata["homekit"] == ItemMetadata(value="Lighting", config={})
+
+
+def test_get_item_metadata_fetches_specific_namespace_from_metadata_endpoint():
+    session = RecordingSession()
+    session.next_get = FakeResponse({"value": "Point", "config": {"relatesTo": "x"}})
+    client = _client_with_session(session)
+
+    metadata = client.get_item_metadata("TestItem", namespace="semantics")
+
+    assert session.requests == [
+        (
+            "GET",
+            "http://openhab.example/rest/items/TestItem/metadata/semantics",
+            {},
+        )
+    ]
+    assert metadata == {
+        "semantics": ItemMetadata(value="Point", config={"relatesTo": "x"})
+    }

--- a/tests/test_openhab_client.py
+++ b/tests/test_openhab_client.py
@@ -64,12 +64,16 @@ def test_create_item_excludes_metadata_from_payload():
     }
 
 
-def test_get_item_metadata_fetches_all_namespaces_from_metadata_endpoint():
+def test_get_item_metadata_fetches_all_namespaces_from_item_endpoint():
     session = RecordingSession()
     session.next_get = FakeResponse(
         {
-            "semantics": {"value": "Point", "config": {"isPointOf": "Kitchen"}},
-            "homekit": {"value": "Lighting", "config": {}},
+            "type": "String",
+            "name": "TestItem",
+            "metadata": {
+                "semantics": {"value": "Point", "config": {"isPointOf": "Kitchen"}},
+                "homekit": {"value": "Lighting", "config": {}},
+            },
         }
     )
     client = _client_with_session(session)
@@ -77,7 +81,11 @@ def test_get_item_metadata_fetches_all_namespaces_from_metadata_endpoint():
     metadata = client.get_item_metadata("TestItem")
 
     assert session.requests == [
-        ("GET", "http://openhab.example/rest/items/TestItem/metadata", {})
+        (
+            "GET",
+            "http://openhab.example/rest/items/TestItem",
+            {"params": {"metadata": ".*"}},
+        )
     ]
     assert metadata["semantics"] == ItemMetadata(
         value="Point", config={"isPointOf": "Kitchen"}
@@ -85,9 +93,15 @@ def test_get_item_metadata_fetches_all_namespaces_from_metadata_endpoint():
     assert metadata["homekit"] == ItemMetadata(value="Lighting", config={})
 
 
-def test_get_item_metadata_fetches_specific_namespace_from_metadata_endpoint():
+def test_get_item_metadata_fetches_specific_namespace_from_item_endpoint():
     session = RecordingSession()
-    session.next_get = FakeResponse({"value": "Point", "config": {"relatesTo": "x"}})
+    session.next_get = FakeResponse(
+        {
+            "type": "String",
+            "name": "TestItem",
+            "metadata": {"semantics": {"value": "Point", "config": {"relatesTo": "x"}}},
+        }
+    )
     client = _client_with_session(session)
 
     metadata = client.get_item_metadata("TestItem", namespace="semantics")
@@ -95,10 +109,27 @@ def test_get_item_metadata_fetches_specific_namespace_from_metadata_endpoint():
     assert session.requests == [
         (
             "GET",
-            "http://openhab.example/rest/items/TestItem/metadata/semantics",
-            {},
+            "http://openhab.example/rest/items/TestItem",
+            {"params": {"metadata": "semantics"}},
         )
     ]
     assert metadata == {
         "semantics": ItemMetadata(value="Point", config={"relatesTo": "x"})
     }
+
+
+def test_list_metadata_namespaces_uses_namespaces_endpoint():
+    session = RecordingSession()
+    session.next_get = FakeResponse(["homekit", "semantics"])
+    client = _client_with_session(session)
+
+    namespaces = client.list_metadata_namespaces("TestItem")
+
+    assert session.requests == [
+        (
+            "GET",
+            "http://openhab.example/rest/items/TestItem/metadata/namespaces",
+            {},
+        )
+    ]
+    assert namespaces == ["homekit", "semantics"]


### PR DESCRIPTION
## Summary

The openHAB MCP previously exposed no way to read or write item metadata
(namespaces like `semantics`, `expire`, `homekit`, …). This PR wires up
the `/rest/items/{name}/metadata/{namespace}` endpoints and surfaces them
as MCP tools.

## Changes

- **`models.py`**: new `ItemMetadata` model; `Item` gains a
  `metadata: Dict[str, ItemMetadata]` field (defaults to `{}`, so
  existing callers are unaffected).
- **`openhab_client.py`**:
  - `get_item(item_name, metadata=...)` — optional namespace selector
    passed through to openHAB (regex / comma-separated list / `.*`).
  - `get_item_metadata(item_name, namespace=None)` — fetch one or all
    namespaces for an item.
  - `set_item_metadata(item_name, namespace, value, config=None)` —
    create or update. Handles openHAB's `201 Created` with empty body by
    echoing the written payload back as `ItemMetadata`.
  - `delete_item_metadata(item_name, namespace)`.
  - `list_metadata_namespaces(item_name)` — returns sorted namespace keys.
- **`openhab_mcp_server.py`**: four new MCP tools mirroring the client
  methods, plus an optional `metadata` selector on the existing `get_item`
  tool for one-shot item + metadata fetches.

## Test plan

Exercised end-to-end against the live openHAB instance via the MCP
streamable-http endpoint:

- [x] `set_item_metadata` on a new namespace (201 path) returns the
      written entry
- [x] `set_item_metadata` on an existing namespace (200 + body path)
      returns the updated entry
- [x] `get_item_metadata` with and without a namespace selector
- [x] `list_metadata_namespaces` returns the expected keys
- [x] `delete_item_metadata` removes the entry; follow-up `get` returns
      `{}`
- [x] `get_item` with `metadata="semantics"` includes the metadata block
- [x] Clean error messages for unknown item / unknown namespace
