### PR TITLE
[codex] Fix remote transport slash redirects

### DIFF
--- a/openhab_mcp_server.py
+++ b/openhab_mcp_server.py
@@ -19,7 +19,7 @@ from dotenv import load_dotenv
 # Import the MCP server implementation
 from mcp.server import FastMCP
 from starlette.applications import Starlette
-from starlette.routing import Mount
+from starlette.routing import Mount, Route
 
 # Import our modules
 from models import (
@@ -445,22 +445,56 @@ def delete_all_links_for_object(object_name: str) -> bool:
     return openhab_client.delete_all_links_for_object(object_name)
 
 
+class _SlashlessMountEndpoint:
+    """Forward an exact mount path request to the mounted app's root path."""
+
+    def __init__(self, app: Starlette, root_path_suffix: str):
+        self.app = app
+        self.root_path_suffix = root_path_suffix
+
+    async def __call__(self, scope, receive, send):
+        forwarded_scope = dict(scope)
+        forwarded_scope["path"] = "/"
+        forwarded_scope["raw_path"] = b"/"
+        forwarded_scope["root_path"] = (
+            forwarded_scope.get("root_path", "") + self.root_path_suffix
+        )
+        await self.app(forwarded_scope, receive, send)
+
+
+def _disable_redirect_slashes(app: Starlette) -> None:
+    app.router.redirect_slashes = False
+
+
+def _transport_routes(path: str, app: Starlette) -> List[Any]:
+    _disable_redirect_slashes(app)
+    return [
+        Route(path, endpoint=_SlashlessMountEndpoint(app, path), methods=None),
+        Mount(path, app=app),
+    ]
+
+
 def _build_remote_app() -> Starlette:
     mcp.settings.streamable_http_path = "/"
     mcp.settings.sse_path = "/"
+
+    streamable_http_app = mcp.streamable_http_app()
+    sse_app = mcp.sse_app()
 
     @contextlib.asynccontextmanager
     async def lifespan(app: Starlette):
         async with mcp.session_manager.run():
             yield
 
-    return Starlette(
+    app = Starlette(
         routes=[
-            Mount("/mcp", app=mcp.streamable_http_app()),
-            Mount("/sse", app=mcp.sse_app()),
+            *_transport_routes("/mcp", streamable_http_app),
+            *_transport_routes("/sse", sse_app),
         ],
         lifespan=lifespan,
     )
+    _disable_redirect_slashes(app)
+    return app
 
 
 def main():

--- a/test_openhab.py
+++ b/test_openhab.py
@@ -53,7 +53,8 @@ def main():
         pagination = items_page.pagination
         print(
             f"Found {pagination.total_elements} items "
-            f"(showing {len(items)} on page {pagination.page}/{max(pagination.total_pages, 1)}):"
+            f"(showing {len(items)} on page "
+            f"{pagination.page}/{max(pagination.total_pages, 1)}):"
         )
 
         for item in items[:10]:  # Show first 10 items
@@ -64,8 +65,7 @@ def main():
         if pagination.has_next:
             remaining = max(
                 0,
-                pagination.total_elements
-                - pagination.page * pagination.page_size,
+                pagination.total_elements - pagination.page * pagination.page_size,
             )
             if remaining > 0:
                 print(f"  ... and {remaining} more items")
@@ -81,7 +81,8 @@ def main():
         pagination = things_page.pagination
         print(
             f"Found {pagination.total_elements} things "
-            f"(showing {len(things)} on page {pagination.page}/{max(pagination.total_pages, 1)}):"
+            f"(showing {len(things)} on page "
+            f"{pagination.page}/{max(pagination.total_pages, 1)}):"
         )
 
         for thing in things[:5]:  # Show first 5 things
@@ -93,8 +94,7 @@ def main():
         if pagination.has_next:
             remaining = max(
                 0,
-                pagination.total_elements
-                - pagination.page * pagination.page_size,
+                pagination.total_elements - pagination.page * pagination.page_size,
             )
             if remaining > 0:
                 print(f"  ... and {remaining} more things")
@@ -146,12 +146,14 @@ def main():
         if links:
             test_link = links[0]
             print(
-                f"\n--- Testing get_link() for '{test_link.itemName}' -> '{test_link.channelUID}' ---"
+                "\n--- Testing get_link() for "
+                f"'{test_link.itemName}' -> '{test_link.channelUID}' ---"
             )
             specific_link = client.get_link(test_link.itemName, test_link.channelUID)
             if specific_link:
                 print(
-                    f"Retrieved link: {specific_link.itemName} -> {specific_link.channelUID}"
+                    f"Retrieved link: {specific_link.itemName} -> "
+                    f"{specific_link.channelUID}"
                 )
                 print(f"Configuration: {specific_link.configuration}")
                 print(f"Editable: {specific_link.editable}")

--- a/tests/test_transport_smoke.py
+++ b/tests/test_transport_smoke.py
@@ -1,6 +1,11 @@
 import importlib
 import sys
 
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
 
 def _load_module():
     if "openhab_mcp_server" in sys.modules:
@@ -70,3 +75,43 @@ def test_mode_overrides_transport(monkeypatch):
     module = _load_module()
 
     assert module.MCP_MODE == "remote"
+
+
+def test_remote_app_disables_trailing_slash_redirects(monkeypatch):
+    _set_base_env(monkeypatch)
+    monkeypatch.setenv("MCP_MODE", "remote")
+
+    module = _load_module()
+    app = module._build_remote_app()
+
+    assert app.router.redirect_slashes is False
+    for route in app.routes:
+        child_app = getattr(route, "app", None)
+        child_router = getattr(child_app, "router", None)
+        if child_router is not None:
+            assert child_router.redirect_slashes is False
+
+
+def test_transport_routes_accept_slashless_and_slash_paths_without_redirect(
+    monkeypatch,
+):
+    _set_base_env(monkeypatch)
+    module = _load_module()
+
+    async def child_root(request):
+        return PlainTextResponse(request.scope["path"])
+
+    child_app = Starlette(routes=[Route("/", child_root)])
+    app = Starlette(routes=module._transport_routes("/example", child_app))
+    app.router.redirect_slashes = False
+
+    with TestClient(app, follow_redirects=False) as client:
+        slashless_response = client.get("/example")
+        slash_response = client.get("/example/")
+
+    assert slashless_response.status_code == 200
+    assert slashless_response.text == "/"
+    assert "location" not in slashless_response.headers
+
+    assert slash_response.status_code == 200
+    assert "location" not in slash_response.headers


### PR DESCRIPTION
## Summary

- Disable trailing-slash redirects for remote MCP transports and their FastMCP child routers.
- Add explicit slashless route forwarding so `/mcp` and `/sse` resolve directly while `/mcp/`, `/sse/`, and SSE subpaths continue to work.
- Add regression coverage for the no-redirect routing contract.
- Format `test_openhab.py` so full-repo flake8 passes.

## Root Cause

Starlette `Mount` serves the mounted app at the slash-suffixed path and normally redirects the slashless mount path. FastMCP's generated transport apps also have their own routers, so reverse proxies can see redirects from either layer.

## Validation

- `uv run pytest tests/test_transport_smoke.py -q`
- `uv run pytest -q`
- `uv run black --check .`
- `uv run isort --check-only .`
- `uv run flake8`
- Built the repo container via `make dev-env`.
- Ran an isolated container validation stack using `openhab/openhab:latest` and the repo-built MCP image.
- Confirmed direct non-redirect responses for `GET -I /mcp`, `/mcp/`, `/sse`, and `/sse/` on the running MCP container.
- Ran both slashless transport clients successfully against the test openHAB instance:
  - `MCP_HTTP_BASE=http://localhost:18082 uv run python scripts/mcp_client_streamable_list_items.py`
  - `MCP_HTTP_BASE=http://localhost:18082 uv run python scripts/mcp_client_sse_list_items.py`

Fixes #13.
